### PR TITLE
Remove unsupported Python version

### DIFF
--- a/app/mypy_playground/sandbox.py
+++ b/app/mypy_playground/sandbox.py
@@ -48,7 +48,7 @@ ARGUMENT_FLAGS_STRICT = (
 )
 
 ARGUMENT_FLAGS = ARGUMENT_FLAGS_NORMAL + ARGUMENT_FLAGS_STRICT
-PYTHON_VERSIONS = ["3.8", "3.7", "3.6", "3.5", "3.4", "3.3", "2.7"]
+PYTHON_VERSIONS = ["3.8", "3.7", "3.6", "3.5", "3.4", "2.7"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes https://github.com/ymyzk/mypy-playground/issues/80
We could also consider removing 3.4, since typeshed doesn't support it,
even if mypy doesn't complain.