### PR TITLE
set default flags to be as strict as possible

### DIFF
--- a/app/mypy_playground/handlers.py
+++ b/app/mypy_playground/handlers.py
@@ -13,7 +13,7 @@ import tornado.web
 from mypy_playground import gist
 from mypy_playground.prometheus import PrometheusMixin
 from mypy_playground.sandbox import run_typecheck_in_sandbox
-from mypy_playground.sandbox.base import AbstractSandbox, ARGUMENT_FLAGS, PYTHON_VERSIONS
+from mypy_playground.sandbox.base import AbstractSandbox, ARGUMENT_FLAGS, ARGUMENT_FLAGS_DEFAULT, PYTHON_VERSIONS
 from mypy_playground.sandbox.cloud_functions import CloudFunctionsSandbox
 from mypy_playground.sandbox.docker import DockerSandbox
 from mypy_playground.utils import get_mypy_versions
@@ -38,7 +38,7 @@ fib("10")
 class IndexHandler(tornado.web.RequestHandler):
     async def get(self) -> None:
         mypy_versions = get_mypy_versions()
-        default: dict[str, bool | str] = {flag: False for flag in ARGUMENT_FLAGS}
+        default: dict[str, bool | str] = {flag: flag in ARGUMENT_FLAGS_DEFAULT for flag in ARGUMENT_FLAGS}
         default["mypyVersion"] = mypy_versions[0][1]
         default["pythonVersion"] = PYTHON_VERSIONS[0]
         context = {

--- a/app/mypy_playground/sandbox/base.py
+++ b/app/mypy_playground/sandbox/base.py
@@ -41,6 +41,31 @@ ARGUMENT_FLAGS_STRICT = (
     "warn-unused-ignores",
 )
 
+ARGUMENT_FLAGS_DEFAULT = (
+    "strict",
+    "check-untyped-defs",
+    "disallow-any-decorated",
+    "disallow-any-expr",
+    "disallow-any-explicit",
+    "disallow-any-generics",
+    "disallow-any-unimported",
+    "disallow-incomplete-defs",
+    "disallow-subclassing-any",
+    "disallow-untyped-calls",
+    "disallow-untyped-decorators",
+    "disallow-untyped-defs",
+    "no-implicit-optional",
+    "no-implicit-reexport",
+    "show-error-codes",
+    "strict-equality",
+    "warn-incomplete-stub",
+    "warn-redundant-casts",
+    "warn-return-any",
+    "warn-unreachable",
+    "warn-unused-configs",
+    "warn-unused-ignores",
+)
+
 ARGUMENT_FLAGS = ARGUMENT_FLAGS_NORMAL + ARGUMENT_FLAGS_STRICT
 PYTHON_VERSIONS = ["3.10", "3.9", "3.8", "3.7", "3.6", "3.5", "3.4", "2.7"]
 


### PR DESCRIPTION
rational: mypy's defaults are this way to accommodate gradual typing of existing projects, when a user wants to play around in the playground it's more of an inconvenience to enable all these flags every time.

resolves #151