### PR TITLE
Use Python 3.11 for Cloud Functions based sandbox

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -15,7 +15,7 @@ on:
         description: Runtime version
         required: true
         type: string
-        default: python310
+        default: python311
 
 permissions:
   contents: read
@@ -23,7 +23,7 @@ permissions:
 
 env:
   MYPY_VERSION: ${{ github.event.inputs.mypy_version || 'master' }}
-  RUNTIME: ${{ github.event.inputs.runtime || 'python310' }}
+  RUNTIME: ${{ github.event.inputs.runtime || 'python311' }}
 
 jobs:
   gcp-deploy:

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -18,7 +18,7 @@ $ ./update_latest.sh 0.930
 
 ### Deploy to Cloud Functions
 ```console
-$ RUNTIME=python310 REGION=us-central1 INVOKER_MEMBER=serviceAccount:... SERVICE_ACCOUNT=... ./deploy.sh latest
+$ RUNTIME=python311 REGION=us-central1 INVOKER_MEMBER=serviceAccount:... SERVICE_ACCOUNT=... ./deploy.sh latest
 ```
 
 ### Build all Docker images

--- a/sandbox/cloud_functions/deploy.sh
+++ b/sandbox/cloud_functions/deploy.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 : "${MAX_INSTANCES:=3}"
 : "${MEMORY:=1024MB}"
 : "${REGION:=asia-northeast1}"
-: "${RUNTIME:=python310}"
+: "${RUNTIME:=python311}"
 
 deploy() {
   VERSION="$1"


### PR DESCRIPTION
#280. This PR upgrades the Cloud Functions based sandbox to use Python 3.11 by default. I'm working on a change to support Python 3.11 + Docker in a separate PR. 