### PR TITLE
Use Docker:24-dind-rootless for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,10 @@ services:
       - ./app/frontend/utils:/app/utils
 
   docker:
-    image: docker:24-dind
+    image: docker:24-dind-rootless
     privileged: true
     environment:
+      DOCKER_HOST: unix:///run/user/1000/docker.sock
       DOCKER_TLS_CERT_DIR: /certs
     volumes:
       - docker_certs:/certs


### PR DESCRIPTION
Resolves #267.

When migrating from the existing dind image, you may need to recreate certificates for connecting to Docker by removing the volume. `docker volume rm mypy-playground_docker_certs`