### PR TITLE
(🎁) add ruff config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         language_version: python3.11
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.291
+    rev: v0.0.292
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -7,3 +7,9 @@ module = [
     'google.*',
 ]
 ignore_missing_imports = true
+
+[tool.ruff]
+select = ["E", "F", "I", "W", "UP"]
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["S101", "I001"]


### PR DESCRIPTION
Ruff covers flake8's ruleset, but also the ruleset of 20 or so other linters, plus it's much much faster, also it can automatically fix a lot of issues. We can remove a bunch of these configs if you think it's too many rules to enforce. We can just stick to the flake8 ones maybe.

https://github.com/astral-sh/ruff
https://docs.astral.sh/ruff/rules