### PR TITLE
Fix tox environments to run on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ env:
   DOCKER_BUILDKIT: 1
 jobs:
   test_app:
+    needs:
+      - test_frontend
     name: Test app
     runs-on: ubuntu-latest
     strategy:
@@ -13,6 +15,10 @@ jobs:
         python-version: ['3.11']
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v3
+      with:
+        name: frontend
+        path: app/static
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -46,6 +52,10 @@ jobs:
         npm run lint
         npm run test:ci
       working-directory: ./app/frontend
+    - uses: actions/upload-artifact@v3
+      with:
+        name: frontend
+        path: app/frontend/out
 
   build_docker_images:
     name: Build and push Docker images

--- a/app/setup.cfg
+++ b/app/setup.cfg
@@ -7,7 +7,7 @@ skipsdist = true
 
 [gh-actions]
 python =
-    3.11: ruff, mypy
+    3.11: mypy, pre-commit, py311
 
 [testenv]
 deps =


### PR DESCRIPTION
### Description
Fix tox-gh-action's config to run all the environments on GitHub Actions as the list of environments became outdated over time.

Fix GitHub Actions config as some of the backend tests require static files generated by the frontend.

### Expected Behavior
`mypy`, `pre-commit`, and `py311` environments are executed on GitHub Actions.
