### PR TITLE
Remove "next export" and introduce Caddy for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Development
 1. Run `docker compose up -d` to start an app and Docker for running mypy
 2. Run `docker compose exec docker docker build --pull -t ymyzk/mypy-playground-sandbox:latest /sandbox/latest` to build a Docker image
-3. Open http://localhost:3000
+3. Open http://localhost:8000
 
 ## Components
 - [app](app): Application server

--- a/app/Caddyfile
+++ b/app/Caddyfile
@@ -1,0 +1,8 @@
+:8000
+
+reverse_proxy /api/ app:8080
+reverse_proxy /* frontend:3000
+
+log {
+    output stderr
+}

--- a/app/README.md
+++ b/app/README.md
@@ -5,11 +5,13 @@
 ### Local development
 ```mermaid
 graph TD
+    Caddy["Caddy reverse proxy (:8000)"]
     Next["Next.js server (:3000)"]
     Tornado["Tornado server (:8080)"]
 
-    Browser --> Next
-    Next -->|/api/| Tornado
+    Browser --> Caddy
+    Caddy -->|/api/| Tornado
+    Caddy -->|/*| Next
 ```
 
 ### Production

--- a/app/frontend/next.config.js
+++ b/app/frontend/next.config.js
@@ -1,15 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "export",
   reactStrictMode: true,
-  rewrites: async () => ({
-    fallback: [
-      {
-        source: "/api/:path*",
-        // TODO: this is for local Docker development only
-        destination: "http://app:8080/api/:path*",
-      },
-    ],
-  }),
 };
 
 module.exports = nextConfig;

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export",
+    "build": "next build",
     "start": "next start",
     "test": "jest --watch",
     "test:ci": "jest --ci",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,12 @@
 version: "3"
 services:
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - 127.0.0.1:8000:8000
+    volumes:
+      - ./app/Caddyfile:/etc/caddy/Caddyfile:ro
+
   app:
     build: app
     ports:


### PR DESCRIPTION
### Description
* Remove use of `next export` to prepare for the Next.js upgrade
* Introduce Caddy as a reverse proxy for local development

### Expected Behavior
URL used for local development will be http://localhost:8000 instead of http://localhost:3000
Explain the expected behavior of this change.
