### PR TITLE
Use groups in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,22 @@ updates:
     directory: "/app/frontend"
     schedule:
       interval: "weekly"
+    groups:
+      jest:
+        patterns:
+          - "jest"
+          - "jest-environment-jsdom"
+      next:
+        patterns:
+          - "eslint-config-next"
+          - "next"
+          - "@next/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
   - package-ecosystem: "pip"
     directory: "/app/frontend"
     schedule:


### PR DESCRIPTION
### Description
Use groups in dependabot.yml to reduce the number of PRs created.

### Expected Behavior
Updates for certain dependencies will be grouped automatically.