### PR TITLE
Fix dependency resolution errors for basedmypy 2.6.0 and 2.7.0

### DIFF
--- a/sandbox/cloud_functions/basedmypy-2.6.0/requirements.txt
+++ b/sandbox/cloud_functions/basedmypy-2.6.0/requirements.txt
@@ -10,7 +10,7 @@ basedtyping==0.1.5
     # via basedmypy
 mypy-extensions==1.0.0
     # via basedmypy
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   basedmypy
     #   basedtyping

--- a/sandbox/cloud_functions/basedmypy-2.7.0/requirements.txt
+++ b/sandbox/cloud_functions/basedmypy-2.7.0/requirements.txt
@@ -10,7 +10,7 @@ basedtyping==0.1.5
     # via basedmypy
 mypy-extensions==1.0.0
     # via basedmypy
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   basedmypy
     #   basedtyping


### PR DESCRIPTION
### Description
Fix the dependency resolution error introduced in #774 
```
  Downloading basedmypy-2.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl.metadata (6.2 kB)
Collecting basedtyping==0.1.5 (from -r requirements.txt (line 9))
  Downloading basedtyping-0.1.5-py3-none-any.whl.metadata (487 bytes)
Collecting mypy-extensions==1.0.0 (from -r requirements.txt (line 11))
  Downloading mypy_extensions-1.0.0-py3-none-any.whl.metadata (1.1 kB)
Collecting typing-extensions==4.11.0 (from -r requirements.txt (line 13))
  Downloading typing_extensions-4.11.0-py3-none-any.whl.metadata (3.0 kB)
INFO: pip is looking at multiple versions of basedtyping to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 7), -r requirements.txt (line 9) and typing-extensions==4.11.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested typing-extensions==4.11.0
    basedmypy 2.6.0 depends on typing-extensions>=4.6.0
    basedtyping 0.1.5 depends on typing_extensions<5.0.0 and >=4.12.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts; Error ID: 656dd225.
```

### Expected Behavior
Cloud Functions sandbox for basedmypy 2.6.0 and 2.7.0 will be deployed successfully.