### PR TITLE
Run frontend CI on Node.js v22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.x, 22.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
@@ -58,6 +58,7 @@ jobs:
         npm run test:ci
       working-directory: ./app/frontend
     - uses: actions/upload-artifact@v4
+      if: matrix.node-version == '20.x'
       with:
         name: frontend
         path: app/frontend/out


### PR DESCRIPTION
<!-- DO NOT REMOVE THE TEMPLATE. -->
<!-- A PR that does not follow the template might not be reviewed or merged. -->
### Description
Run frontend CI on Node.js v22 in addition to v20 to prepare for the upgrade.

### Expected Behavior
CI passes.