### PR TITLE
Add `--strict-bytes` option from `mypy@1.15`

### DIFF
--- a/app/mypy_playground/sandbox/base.py
+++ b/app/mypy_playground/sandbox/base.py
@@ -22,6 +22,7 @@ ARGUMENT_FLAGS_STRICT = (
     "allow-redefinition",
     "allow-untyped-globals",
     "strict",
+    "strict-bytes",
     "check-untyped-defs",
     "disallow-any-decorated",
     "disallow-any-expr",


### PR DESCRIPTION
<!-- DO NOT REMOVE THE TEMPLATE. -->
<!-- A PR that does not follow the template might not be reviewed or merged. -->
### Description

See

```
» mypy --help | grep strict-bytes    
  --strict-bytes            Disable treating bytearray and memoryview as
                            subtypes of bytes (inverse: --no-strict-bytes)
                               
```

And https://github.com/python/mypy/blob/master/CHANGELOG.md#--strict-bytes

### Expected Behavior

I expect new option to show up in the options menu.
