### PR TITLE
Update docker-compose.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3"
 services:
   caddy:
-    image: caddy:2-alpine
+    image: caddy:2.10-alpine
     ports:
       - 127.0.0.1:8000:8000
     volumes:
@@ -32,7 +31,7 @@ services:
       - ./app/frontend/utils:/app/utils
 
   docker:
-    image: docker:24-dind-rootless
+    image: docker:28.3-dind-rootless
     privileged: true
     environment:
       DOCKER_HOST: unix:///run/user/1000/docker.sock


### PR DESCRIPTION
<!-- DO NOT REMOVE THE TEMPLATE. -->
<!-- A PR that does not follow the template might not be reviewed or merged. -->
### Description
- Use newer version of Docker images for local development.
- Remove `version:` key as this is deprecated.
- Automatically upgrade images in `docker-compose.yml` using Dependabot

### Expected Behavior
- `docker compose up -d` upgrades Docker images used for local development if needed.
- Dependabot will upgrade Docker images in `docker-compose.yml` every week.
