### PR TITLE
Ignore errors from add-mypy-version.yml when no new version is available

### DIFF
--- a/.github/workflows/add-mypy-version.yml
+++ b/.github/workflows/add-mypy-version.yml
@@ -73,24 +73,29 @@ jobs:
             fi
           fi
         working-directory: ./sandbox
+        continue-on-error: ${{ github.event_name == 'schedule' }}
 
       - name: Set up Python
+        if: steps.find_new_versions.outcome == 'success'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ github.event.inputs.python_version }}
 
       - name: Set up pip-tools
+        if: steps.find_new_versions.outcome == 'success'
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install pip-tools
 
       - name: Add version and update latest tag
+        if: steps.find_new_versions.outcome == 'success'
         run: |
           ./add_version.sh ${{ steps.inputs.outputs.package }} ${{ steps.find_new_versions.outputs.new_version }}
           ./update_latest.sh ${{ steps.inputs.outputs.package }} ${{ steps.find_new_versions.outputs.new_version }}
         working-directory: ./sandbox
 
       - name: Create pull request
+        if: steps.find_new_versions.outcome == 'success'
         uses: peter-evans/create-pull-request@v7
         with:
             token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- DO NOT REMOVE THE TEMPLATE. -->
<!-- A PR that does not follow the template might not be reviewed or merged. -->
### Description
Reduce errors when no new mypy versions are available when executing a daily CI workflow.

### Expected Behavior
When the `add-mypy-version.yml` workflow is triggered by the schedule (cron) event and when no new mypy version is available, the workflow should skip the remaining steps and succeed, instead of failing the entire workflow.