### PR TITLE
Convert App and Header components to functional components

### DIFF
--- a/app/frontend/src/components/Header.tsx
+++ b/app/frontend/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState } from "react";
 import {
   Button,
   Col,
@@ -30,184 +30,166 @@ type Props = {
   onConfigChange: (configDiff: ConfigDiff) => void;
 };
 
-type State = {
-  aboutIsOpen: boolean;
-  navbarIsOpen: boolean;
-  optionsIsOpen: boolean;
-};
+function Header({ context, config, status, onGistClick, onRunClick, onConfigChange }: Props) {
+  const [aboutIsOpen, setAboutIsOpen] = useState(false);
+  const [navbarIsOpen, setNavbarIsOpen] = useState(false);
+  const [optionsIsOpen, setOptionsIsOpen] = useState(false);
 
-class Header extends React.Component<Props, State> {
-  state = {
-    aboutIsOpen: false,
-    navbarIsOpen: false,
-    optionsIsOpen: false,
-  };
+  const toggleAbout = () => setAboutIsOpen((prev) => !prev);
+  const toggleNavbar = () => setNavbarIsOpen((prev) => !prev);
+  const toggleOptions = () => setOptionsIsOpen((prev) => !prev);
 
-  toggle(name: string) {
-    const stateName = `${name}IsOpen`;
-    // @ts-expect-error - Dynamic key access
-    this.setState((prevState) => ({
-      // @ts-expect-error - Dynamic key access
-      [stateName]: !prevState[stateName],
-    }));
-  }
+  const half = Math.ceil(context.flags.length / 2);
+  const flagsColumns = [context.flags.slice(0, half), context.flags.slice(half, context.flags.length)];
 
-  render() {
-    const { context, config, status, onGistClick, onRunClick, onConfigChange } = this.props;
-    const { aboutIsOpen, navbarIsOpen, optionsIsOpen } = this.state;
-
-    const half = Math.ceil(context.flags.length / 2);
-    const flagsColumns = [context.flags.slice(0, half), context.flags.slice(half, context.flags.length)];
-
-    return (
-      <header className={styles.header}>
-        <Navbar color="primary" dark expand="lg">
-          {/* .mb-0 is for overriding margin by .h1 */}
-          <NavbarBrand href="/" className="h1 mb-0">
-            mypy Playground
-          </NavbarBrand>
-          <NavbarToggler onClick={() => this.toggle("navbar")} />
-          <Collapse navbar isOpen={navbarIsOpen}>
-            <Nav navbar className="me-auto my-2 my-lg-0">
-              <Form className="d-flex flex-wrap flex-md-nowrap">
-                <Button
-                  color="light"
-                  className={`me-2 mb-2 mb-lg-0 ${styles.run}`}
-                  disabled={status === "running"}
-                  onClick={onRunClick}
-                >
-                  Run
-                </Button>
-                <Button
-                  color="light"
-                  className="me-2 mb-2 mb-lg-0"
-                  disabled={status === "creating_gist"}
-                  onClick={onGistClick}
-                >
-                  Gist
-                </Button>
-                {/* Using w-auto for <Input type="select"> to override "width: 100%" set by
+  return (
+    <header className={styles.header}>
+      <Navbar color="primary" dark expand="lg">
+        {/* .mb-0 is for overriding margin by .h1 */}
+        <NavbarBrand href="/" className="h1 mb-0">
+          mypy Playground
+        </NavbarBrand>
+        <NavbarToggler onClick={toggleNavbar} />
+        <Collapse navbar isOpen={navbarIsOpen}>
+          <Nav navbar className="me-auto my-2 my-lg-0">
+            <Form className="d-flex flex-wrap flex-md-nowrap">
+              <Button
+                color="light"
+                className={`me-2 mb-2 mb-lg-0 ${styles.run}`}
+                disabled={status === "running"}
+                onClick={onRunClick}
+              >
+                Run
+              </Button>
+              <Button
+                color="light"
+                className="me-2 mb-2 mb-lg-0"
+                disabled={status === "creating_gist"}
+                onClick={onGistClick}
+              >
+                Gist
+              </Button>
+              {/* Using w-auto for <Input type="select"> to override "width: 100%" set by
                     the form-select class. */}
-                <Input
-                  type="select"
-                  className="me-2 mb-2 mb-lg-0 w-auto"
-                  title="mypy Version"
-                  value={config.mypyVersion}
-                  onChange={(e) => onConfigChange({ mypyVersion: e.target.value })}
-                >
-                  {context.mypyVersions.map(([name, id]) => (
-                    <option key={id} value={id}>
-                      {name}
-                    </option>
-                  ))}
-                </Input>
-                <Input
-                  type="select"
-                  className="me-2 mb-2 mb-lg-0 w-auto"
-                  title="Python Version (--python--version)"
-                  value={config.pythonVersion}
-                  onChange={(e) => onConfigChange({ pythonVersion: e.target.value })}
-                >
-                  {context.pythonVersions.map((ver) => (
-                    <option key={ver} value={ver}>
-                      Python {ver}
-                    </option>
-                  ))}
-                </Input>
-                <Button
-                  color="light"
-                  className="me-2 mb-2 mb-lg-0"
-                  data-toggle="modal"
-                  data-target="#options-modal"
-                  onClick={() => this.toggle("options")}
-                >
-                  Options
-                </Button>
-              </Form>
-            </Nav>
-            <Button
-              color="light"
-              className="my-2 my-lg-0"
-              data-toggle="modal"
-              data-target="#about-modal"
-              onClick={() => this.toggle("about")}
-            >
-              About
-            </Button>
-          </Collapse>
-        </Navbar>
-        <Modal isOpen={optionsIsOpen} toggle={() => this.toggle("options")} className={styles.optionsModal}>
-          <ModalHeader toggle={() => this.toggle("options")}>Options</ModalHeader>
-          <ModalBody>
-            <p>
-              Please see <a href="https://mypy.readthedocs.io/en/stable/command_line.html">mypy&apos;s documentation</a>{" "}
-              to learn effect of each option.
-            </p>
-            <Form>
-              <FormGroup row>
-                {flagsColumns.map((flags) => (
-                  <Col md={6} key={flags[0]}>
-                    {flags.map((flag) => (
-                      <FormGroup check key={flag}>
-                        <Input
-                          type="checkbox"
-                          id={flag}
-                          checked={config[flag] as boolean}
-                          onChange={(e) => onConfigChange({ [flag]: e.target.checked })}
-                        />
-                        <Label check for={flag} className="mb-0">
-                          <code>
-                            --
-                            {flag}
-                          </code>
-                        </Label>
-                      </FormGroup>
-                    ))}
-                  </Col>
+              <Input
+                type="select"
+                className="me-2 mb-2 mb-lg-0 w-auto"
+                title="mypy Version"
+                value={config.mypyVersion}
+                onChange={(e) => onConfigChange({ mypyVersion: e.target.value })}
+              >
+                {context.mypyVersions.map(([name, id]) => (
+                  <option key={id} value={id}>
+                    {name}
+                  </option>
                 ))}
-              </FormGroup>
-              <FormGroup>
-                {Object.entries(context.multiSelectOptions).map(([k, v]) => (
-                  <MultiSelectOption
-                    key={k}
-                    name={k}
-                    choices={v}
-                    values={config[k] as string[]}
-                    onConfigChange={onConfigChange}
-                  />
+              </Input>
+              <Input
+                type="select"
+                className="me-2 mb-2 mb-lg-0 w-auto"
+                title="Python Version (--python--version)"
+                value={config.pythonVersion}
+                onChange={(e) => onConfigChange({ pythonVersion: e.target.value })}
+              >
+                {context.pythonVersions.map((ver) => (
+                  <option key={ver} value={ver}>
+                    Python {ver}
+                  </option>
                 ))}
-              </FormGroup>
+              </Input>
+              <Button
+                color="light"
+                className="me-2 mb-2 mb-lg-0"
+                data-toggle="modal"
+                data-target="#options-modal"
+                onClick={toggleOptions}
+              >
+                Options
+              </Button>
             </Form>
-          </ModalBody>
-          <ModalFooter>
-            <Button color="primary" onClick={() => this.toggle("options")}>
-              Close
-            </Button>
-          </ModalFooter>
-        </Modal>
-        <Modal isOpen={aboutIsOpen} toggle={() => this.toggle("about")}>
-          <ModalHeader toggle={() => this.toggle("about")}>About the mypy Playground</ModalHeader>
-          <ModalBody>
-            <p>
-              The mypy Playground is a web service that receives a Python program with type hints, runs{" "}
-              <a href="http://www.mypy-lang.org/">mypy</a> inside a sandbox, then returns the output.
-            </p>
-            <p>
-              This project is an open source project started by{" "}
-              <a href="https://www.ymyzk.com">Yusuke Miyazaki (@ymyzk)</a>. Source code is available at{" "}
-              <a href="https://github.com/ymyzk/mypy-playground">GitHub</a> and you can run your own mypy Playground
-              instance if you want.
-            </p>
-          </ModalBody>
-          <ModalFooter>
-            <Button color="primary" onClick={() => this.toggle("about")}>
-              Close
-            </Button>
-          </ModalFooter>
-        </Modal>
-      </header>
-    );
-  }
+          </Nav>
+          <Button
+            color="light"
+            className="my-2 my-lg-0"
+            data-toggle="modal"
+            data-target="#about-modal"
+            onClick={toggleAbout}
+          >
+            About
+          </Button>
+        </Collapse>
+      </Navbar>
+      <Modal isOpen={optionsIsOpen} toggle={toggleOptions} className={styles.optionsModal}>
+        <ModalHeader toggle={toggleOptions}>Options</ModalHeader>
+        <ModalBody>
+          <p>
+            Please see <a href="https://mypy.readthedocs.io/en/stable/command_line.html">mypy&apos;s documentation</a>{" "}
+            to learn effect of each option.
+          </p>
+          <Form>
+            <FormGroup row>
+              {flagsColumns.map((flags) => (
+                <Col md={6} key={flags[0]}>
+                  {flags.map((flag) => (
+                    <FormGroup check key={flag}>
+                      <Input
+                        type="checkbox"
+                        id={flag}
+                        checked={config[flag] as boolean}
+                        onChange={(e) => onConfigChange({ [flag]: e.target.checked })}
+                      />
+                      <Label check for={flag} className="mb-0">
+                        <code>
+                          --
+                          {flag}
+                        </code>
+                      </Label>
+                    </FormGroup>
+                  ))}
+                </Col>
+              ))}
+            </FormGroup>
+            <FormGroup>
+              {Object.entries(context.multiSelectOptions).map(([k, v]) => (
+                <MultiSelectOption
+                  key={k}
+                  name={k}
+                  choices={v}
+                  values={config[k] as string[]}
+                  onConfigChange={onConfigChange}
+                />
+              ))}
+            </FormGroup>
+          </Form>
+        </ModalBody>
+        <ModalFooter>
+          <Button color="primary" onClick={toggleOptions}>
+            Close
+          </Button>
+        </ModalFooter>
+      </Modal>
+      <Modal isOpen={aboutIsOpen} toggle={toggleAbout}>
+        <ModalHeader toggle={toggleAbout}>About the mypy Playground</ModalHeader>
+        <ModalBody>
+          <p>
+            The mypy Playground is a web service that receives a Python program with type hints, runs{" "}
+            <a href="http://www.mypy-lang.org/">mypy</a> inside a sandbox, then returns the output.
+          </p>
+          <p>
+            This project is an open source project started by{" "}
+            <a href="https://www.ymyzk.com">Yusuke Miyazaki (@ymyzk)</a>. Source code is available at{" "}
+            <a href="https://github.com/ymyzk/mypy-playground">GitHub</a> and you can run your own mypy Playground
+            instance if you want.
+          </p>
+        </ModalBody>
+        <ModalFooter>
+          <Button color="primary" onClick={toggleAbout}>
+            Close
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </header>
+  );
 }
 
 export default Header;


### PR DESCRIPTION
## Summary

Modernize the frontend codebase by converting the two remaining class components (`App.tsx` and `Header.tsx`) to functional components with React hooks. This aligns the codebase with modern React best practices and eliminates type safety issues.

## Changes

### Header.tsx
- Converted from class component to functional component
- Replaced single state object with three separate `useState` hooks
- Eliminated `toggle(name: string)` method that required `@ts-expect-error` suppressions
- Created type-safe toggle functions: `toggleAbout()`, `toggleNavbar()`, `toggleOptions()`
- Removed all `this` references and manual binding

### App.tsx
- Converted from class component to functional component
- Replaced single state object with 5 separate `useState` hooks
- Converted `componentDidMount` to `useEffect` hook
- Converted `componentDidUpdate` to two separate `useEffect` hooks (config sync, localStorage sync)
- Wrapped methods in `useCallback` with proper dependencies
- Extracted `getInitialConfig()` and `getInitialSource()` helpers to compute initial state
- Renamed imported utilities to avoid naming collisions

## Benefits

- ✅ **Full type safety**: Eliminated all `@ts-expect-error` comments
- ✅ **Modern React patterns**: Using hooks, functional components
- ✅ **Better code organization**: Separated concerns with multiple useEffect hooks
- ✅ **Cleaner code**: Removed verbose class syntax and manual method binding
- ✅ **Exact behavioral parity**: All existing functionality preserved

## Test Plan

- [x] Build: TypeScript compiles without errors
- [x] Lint: ESLint passes with no errors
- [x] Tests: All 9 tests pass
- [x] Dev server: Starts and runs successfully

### Manual Testing Checklist

**Header:**
- [x] Navbar toggle works (mobile viewport)
- [x] Options modal opens/closes
- [x] About modal opens/closes
- [x] Config changes in Options modal propagate correctly

**App:**
- [x] Fresh page load with default config
- [x] URL parameters parse correctly
- [x] Gist parameter loads code from GitHub
- [x] Editor updates and persists to localStorage
- [x] Run button executes typecheck
- [x] Gist button creates and shares gist
- [x] Browser back/forward works with history

🤖 Generated with [Claude Code](https://claude.com/claude-code)