### PR TITLE
Upgrade ruff pre-commit hook from v0.13.0 to v0.15.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.15.1
     hooks:
       - id: ruff-check
         args: [--fix]


### PR DESCRIPTION
### Description
Updated the ruff pre-commit hook version from v0.13.0 to v0.15.1 in the pre-commit configuration. This brings in the latest improvements and bug fixes from the ruff linter.

### Expected Behavior
The pre-commit hook will use the newer version of ruff (v0.15.1) when running code checks and fixes. This may result in different linting behavior or additional checks compared to the previous version, depending on what changes were included in the ruff releases between v0.13.0 and v0.15.1.

https://claude.ai/code/session_012F5i7PY3uqbx2B9PbdoqnE