### PR TITLE
Update Dependabot package ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/app"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
### Description
The project migrated from pip to uv as its package manager, but the Dependabot configuration still referenced the `pip` ecosystem for the `/app` directory. This updates it to `uv` so Dependabot correctly tracks and updates uv-managed dependencies.

### Expected Behavior
Dependabot will use the `uv` package ecosystem to detect and create PRs for dependency updates in the `/app` directory.