### PR TITLE
Persist playground settings in localStorage

### DIFF
--- a/app/frontend/src/components/App.tsx
+++ b/app/frontend/src/components/App.tsx
@@ -34,12 +34,18 @@ function getPersistedConfigDiff(config: Config, defaultConfig: Config): ConfigDi
 function getInitialConfig(context: Context): Config {
   const params = new URLSearchParams(window.location.search);
   const diff: ConfigDiff = {};
+  const allowedMypyVersions = new Set(context.mypyVersions.map(([, id]) => id));
+  const allowedPythonVersions = new Set(context.pythonVersions);
 
   const mypyValue = params.get("mypy");
-  if (mypyValue) diff.mypyVersion = mypyValue;
+  if (mypyValue && allowedMypyVersions.has(mypyValue)) {
+    diff.mypyVersion = mypyValue;
+  }
 
   const pythonValue = params.get("python");
-  if (pythonValue) diff.pythonVersion = pythonValue;
+  if (pythonValue && allowedPythonVersions.has(pythonValue)) {
+    diff.pythonVersion = pythonValue;
+  }
 
   for (const [option, choices] of Object.entries(context.multiSelectOptions)) {
     const optionValue = params.get(option);
@@ -63,8 +69,15 @@ function getInitialConfig(context: Context): Config {
     if (raw) {
       const parsed = JSON.parse(raw) as Record<string, unknown>;
       for (const [key, value] of Object.entries(parsed)) {
-        if (key === "mypyVersion" || key === "pythonVersion") {
-          if (typeof value === "string") {
+        if (key === "mypyVersion") {
+          if (typeof value === "string" && allowedMypyVersions.has(value)) {
+            storedConfig[key] = value;
+          }
+          continue;
+        }
+
+        if (key === "pythonVersion") {
+          if (typeof value === "string" && allowedPythonVersions.has(value)) {
             storedConfig[key] = value;
           }
           continue;

--- a/app/frontend/src/components/App.tsx
+++ b/app/frontend/src/components/App.tsx
@@ -12,6 +12,24 @@ import type { AppResult, Config, ConfigDiff, Context } from "./types";
 
 const CONFIG_STORAGE_KEY = "config";
 
+function configValueEquals(a: boolean | string | string[], b: boolean | string | string[]) {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((value, index) => value === b[index]);
+  }
+  return a === b;
+}
+
+function getPersistedConfigDiff(config: Config, defaultConfig: Config): ConfigDiff {
+  const diff: ConfigDiff = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (!configValueEquals(value, defaultConfig[key])) {
+      diff[key] = value;
+    }
+  }
+  return diff;
+}
+
 // Helper function to parse URL params and compute initial config
 function getInitialConfig(context: Context): Config {
   const params = new URLSearchParams(window.location.search);
@@ -33,7 +51,9 @@ function getInitialConfig(context: Context): Config {
   const flagsValue = params.get("flags");
   if (flagsValue) {
     for (const flag of flagsValue.split(",")) {
-      diff[flag] = true;
+      if (context.flags.includes(flag)) {
+        diff[flag] = true;
+      }
     }
   }
 
@@ -43,10 +63,26 @@ function getInitialConfig(context: Context): Config {
     if (raw) {
       const parsed = JSON.parse(raw) as Record<string, unknown>;
       for (const [key, value] of Object.entries(parsed)) {
-        if (typeof value === "boolean" || typeof value === "string") {
-          storedConfig[key] = value;
-        } else if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
-          storedConfig[key] = value;
+        if (key === "mypyVersion" || key === "pythonVersion") {
+          if (typeof value === "string") {
+            storedConfig[key] = value;
+          }
+          continue;
+        }
+
+        if (context.flags.includes(key)) {
+          if (typeof value === "boolean") {
+            storedConfig[key] = value;
+          }
+          continue;
+        }
+
+        if (key in context.multiSelectOptions) {
+          if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+            const choices = context.multiSelectOptions[key];
+            storedConfig[key] = value.filter((item) => choices.includes(item));
+          }
+          continue;
         }
       }
     }
@@ -139,13 +175,22 @@ export default function App() {
 
   // Sync source to localStorage
   useEffect(() => {
-    window.localStorage.setItem("source", source);
+    try {
+      window.localStorage.setItem("source", source);
+    } catch {
+      // Ignore localStorage write failures.
+    }
   }, [source]);
 
   // Sync options config to localStorage
   useEffect(() => {
-    window.localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config));
-  }, [config]);
+    try {
+      const persistedDiff = getPersistedConfigDiff(config, context.defaultConfig);
+      window.localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(persistedDiff));
+    } catch {
+      // Ignore localStorage write failures.
+    }
+  }, [config, context.defaultConfig]);
 
   const onChange = (newSource: string) => {
     setSource(newSource);

--- a/app/frontend/src/components/App.tsx
+++ b/app/frontend/src/components/App.tsx
@@ -10,6 +10,8 @@ import Header from "./Header";
 import Result from "./Result";
 import type { AppResult, Config, ConfigDiff, Context } from "./types";
 
+const CONFIG_STORAGE_KEY = "config";
+
 // Helper function to parse URL params and compute initial config
 function getInitialConfig(context: Context): Config {
   const params = new URLSearchParams(window.location.search);
@@ -35,8 +37,26 @@ function getInitialConfig(context: Context): Config {
     }
   }
 
+  const storedConfig: ConfigDiff = {};
+  try {
+    const raw = window.localStorage.getItem(CONFIG_STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === "boolean" || typeof value === "string") {
+          storedConfig[key] = value;
+        } else if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+          storedConfig[key] = value;
+        }
+      }
+    }
+  } catch {
+    // Ignore malformed localStorage config payloads.
+  }
+
   return {
     ...context.defaultConfig,
+    ...storedConfig,
     ...diff,
   };
 }
@@ -121,6 +141,11 @@ export default function App() {
   useEffect(() => {
     window.localStorage.setItem("source", source);
   }, [source]);
+
+  // Sync options config to localStorage
+  useEffect(() => {
+    window.localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config));
+  }, [config]);
 
   const onChange = (newSource: string) => {
     setSource(newSource);


### PR DESCRIPTION
### Description
Persist selected mypy options in localStorage and restore them on reload, so returning users keep both their code and option state.

- add localStorage-backed config restore during initial app config load
- persist config updates to localStorage whenever options change
- keep URL query parameters highest precedence over saved values

Closes #179

### Expected Behavior
When reopening the playground, previously selected option flags and selectors are restored together with the saved source code.
