### PR TITLE
Add reset defaults button in options modal

### DIFF
--- a/app/frontend/src/components/Header.tsx
+++ b/app/frontend/src/components/Header.tsx
@@ -45,6 +45,9 @@ function Header({ config, status, onGistClick, onRunClick, onConfigChange }: Pro
   const toggleOptions = () => {
     setOptionsIsOpen((prev) => !prev);
   };
+  const resetOptions = () => {
+    onConfigChange({ ...context.defaultConfig });
+  };
 
   const half = Math.ceil(context.flags.length / 2);
   const flagsColumns = [context.flags.slice(0, half), context.flags.slice(half, context.flags.length)];
@@ -176,6 +179,9 @@ function Header({ config, status, onGistClick, onRunClick, onConfigChange }: Pro
           </Form>
         </ModalBody>
         <ModalFooter>
+          <Button color="secondary" onClick={resetOptions}>
+            Reset defaults
+          </Button>
           <Button color="primary" onClick={toggleOptions}>
             Close
           </Button>


### PR DESCRIPTION
### Description
Add a dedicated "Reset defaults" button to the options modal so users can quickly restore all mypy options to default values.

- add `resetOptions` handler in `Header`
- add `Reset defaults` button in modal footer

Closes #157

### Expected Behavior
Clicking "Reset defaults" resets all option flags/selects to the backend-provided default config.
