### PR TITLE
Add separators between header controls on mobile

### DIFF
--- a/app/frontend/src/components/Header.module.css
+++ b/app/frontend/src/components/Header.module.css
@@ -17,3 +17,13 @@
 .optionsModal {
   max-width: 560px;
 }
+
+.mobileActions {
+  align-items: center;
+}
+
+.mobileSep {
+  margin: 0 0.5rem 0.5rem 0;
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 600;
+}

--- a/app/frontend/src/components/Header.module.css
+++ b/app/frontend/src/components/Header.module.css
@@ -18,12 +18,18 @@
   max-width: 560px;
 }
 
-.mobileActions {
+.actions {
   align-items: center;
 }
 
+.controlGroup {
+  display: flex;
+  align-items: center;
+  margin-right: 0.5rem;
+}
+
 .mobileSep {
-  margin: 0 0.5rem 0.5rem 0;
+  margin: 0 0 0.5rem 0.5rem;
   color: rgba(255, 255, 255, 0.85);
   font-weight: 600;
 }

--- a/app/frontend/src/components/Header.test.tsx
+++ b/app/frontend/src/components/Header.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import Header from "./Header";
+import { AppContext } from "./context";
+import type { Context } from "./types";
+
+const mockContext: Context = {
+  defaultConfig: {
+    mypyVersion: "v1",
+    pythonVersion: "3.12",
+    strict: false,
+    warnReturnAny: false,
+  },
+  initialCode: "print('hi')",
+  pythonVersions: ["3.12"],
+  mypyVersions: [["v1", "v1"]],
+  flags: ["strict", "warnReturnAny"],
+  multiSelectOptions: {},
+  gaTrackingId: null,
+};
+
+describe("Header", () => {
+  test("renders mobile separators with aria-hidden", () => {
+    render(
+      <AppContext value={mockContext}>
+        <Header
+          config={mockContext.defaultConfig}
+          status="ready"
+          onGistClick={vi.fn()}
+          onRunClick={vi.fn()}
+          onConfigChange={vi.fn()}
+        />
+      </AppContext>,
+    );
+
+    const separators = screen.getAllByText("|");
+    expect(separators).toHaveLength(4);
+    separators.forEach((separator) => {
+      expect(separator).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+});

--- a/app/frontend/src/components/Header.tsx
+++ b/app/frontend/src/components/Header.tsx
@@ -48,6 +48,11 @@ function Header({ config, status, onGistClick, onRunClick, onConfigChange }: Pro
 
   const half = Math.ceil(context.flags.length / 2);
   const flagsColumns = [context.flags.slice(0, half), context.flags.slice(half, context.flags.length)];
+  const separator = (
+    <span className={`d-lg-none ${styles.mobileSep}`} aria-hidden="true">
+      |
+    </span>
+  );
 
   return (
     <header className={styles.header}>
@@ -59,76 +64,78 @@ function Header({ config, status, onGistClick, onRunClick, onConfigChange }: Pro
         <NavbarToggler onClick={toggleNavbar} />
         <Collapse navbar isOpen={navbarIsOpen}>
           <Nav navbar className="me-auto my-2 my-lg-0">
-            <Form className={`d-flex flex-wrap flex-md-nowrap ${styles.mobileActions}`}>
-              <Button
-                color="light"
-                className={`me-2 mb-2 mb-lg-0 ${styles.run}`}
-                disabled={status === "running"}
-                onClick={onRunClick}
-              >
-                Run
-              </Button>
-              <span className={`d-lg-none ${styles.mobileSep}`} aria-hidden="true">
-                |
-              </span>
-              <Button
-                color="light"
-                className="me-2 mb-2 mb-lg-0"
-                disabled={status === "creating_gist"}
-                onClick={onGistClick}
-              >
-                Gist
-              </Button>
-              <span className={`d-lg-none ${styles.mobileSep}`} aria-hidden="true">
-                |
-              </span>
-              {/* Using w-auto for <Input type="select"> to override "width: 100%" set by
-                    the form-select class. */}
-              <Input
-                type="select"
-                className="me-2 mb-2 mb-lg-0 w-auto"
-                title="mypy Version"
-                value={config.mypyVersion}
-                onChange={(e) => {
-                  onConfigChange({ mypyVersion: e.target.value });
-                }}
-              >
-                {context.mypyVersions.map(([name, id]) => (
-                  <option key={id} value={id}>
-                    {name}
-                  </option>
-                ))}
-              </Input>
-              <span className={`d-lg-none ${styles.mobileSep}`} aria-hidden="true">
-                |
-              </span>
-              <Input
-                type="select"
-                className="me-2 mb-2 mb-lg-0 w-auto"
-                title="Python Version (--python--version)"
-                value={config.pythonVersion}
-                onChange={(e) => {
-                  onConfigChange({ pythonVersion: e.target.value });
-                }}
-              >
-                {context.pythonVersions.map((ver) => (
-                  <option key={ver} value={ver}>
-                    Python {ver}
-                  </option>
-                ))}
-              </Input>
-              <span className={`d-lg-none ${styles.mobileSep}`} aria-hidden="true">
-                |
-              </span>
-              <Button
-                color="light"
-                className="me-2 mb-2 mb-lg-0"
-                data-toggle="modal"
-                data-target="#options-modal"
-                onClick={toggleOptions}
-              >
-                Options
-              </Button>
+            <Form className={`d-flex flex-wrap flex-md-nowrap ${styles.actions}`}>
+              <div className={styles.controlGroup}>
+                <Button
+                  color="light"
+                  className={`mb-2 mb-lg-0 ${styles.run}`}
+                  disabled={status === "running"}
+                  onClick={onRunClick}
+                >
+                  Run
+                </Button>
+                {separator}
+              </div>
+              <div className={styles.controlGroup}>
+                <Button
+                  color="light"
+                  className="mb-2 mb-lg-0"
+                  disabled={status === "creating_gist"}
+                  onClick={onGistClick}
+                >
+                  Gist
+                </Button>
+                {separator}
+              </div>
+              <div className={styles.controlGroup}>
+                {/* Using w-auto for <Input type="select"> to override "width: 100%" set by
+                      the form-select class. */}
+                <Input
+                  type="select"
+                  className="mb-2 mb-lg-0 w-auto"
+                  title="mypy Version"
+                  value={config.mypyVersion}
+                  onChange={(e) => {
+                    onConfigChange({ mypyVersion: e.target.value });
+                  }}
+                >
+                  {context.mypyVersions.map(([name, id]) => (
+                    <option key={id} value={id}>
+                      {name}
+                    </option>
+                  ))}
+                </Input>
+                {separator}
+              </div>
+              <div className={styles.controlGroup}>
+                <Input
+                  type="select"
+                  className="mb-2 mb-lg-0 w-auto"
+                  title="Python Version (--python--version)"
+                  value={config.pythonVersion}
+                  onChange={(e) => {
+                    onConfigChange({ pythonVersion: e.target.value });
+                  }}
+                >
+                  {context.pythonVersions.map((ver) => (
+                    <option key={ver} value={ver}>
+                      Python {ver}
+                    </option>
+                  ))}
+                </Input>
+                {separator}
+              </div>
+              <div className={styles.controlGroup}>
+                <Button
+                  color="light"
+                  className="mb-2 mb-lg-0"
+                  data-toggle="modal"
+                  data-target="#options-modal"
+                  onClick={toggleOptions}
+                >
+                  Options
+                </Button>
+              </div>
             </Form>
           </Nav>
           <Button

--- a/app/frontend/src/components/Header.tsx
+++ b/app/frontend/src/components/Header.tsx
@@ -59,7 +59,7 @@ function Header({ config, status, onGistClick, onRunClick, onConfigChange }: Pro
         <NavbarToggler onClick={toggleNavbar} />
         <Collapse navbar isOpen={navbarIsOpen}>
           <Nav navbar className="me-auto my-2 my-lg-0">
-            <Form className="d-flex flex-wrap flex-md-nowrap">
+            <Form className={`d-flex flex-wrap flex-md-nowrap ${styles.mobileActions}`}>
               <Button
                 color="light"
                 className={`me-2 mb-2 mb-lg-0 ${styles.run}`}
@@ -68,6 +68,9 @@ function Header({ config, status, onGistClick, onRunClick, onConfigChange }: Pro
               >
                 Run
               </Button>
+              <span className={`d-lg-none ${styles.mobileSep}`} aria-hidden="true">
+                |
+              </span>
               <Button
                 color="light"
                 className="me-2 mb-2 mb-lg-0"
@@ -76,6 +79,9 @@ function Header({ config, status, onGistClick, onRunClick, onConfigChange }: Pro
               >
                 Gist
               </Button>
+              <span className={`d-lg-none ${styles.mobileSep}`} aria-hidden="true">
+                |
+              </span>
               {/* Using w-auto for <Input type="select"> to override "width: 100%" set by
                     the form-select class. */}
               <Input
@@ -93,6 +99,9 @@ function Header({ config, status, onGistClick, onRunClick, onConfigChange }: Pro
                   </option>
                 ))}
               </Input>
+              <span className={`d-lg-none ${styles.mobileSep}`} aria-hidden="true">
+                |
+              </span>
               <Input
                 type="select"
                 className="me-2 mb-2 mb-lg-0 w-auto"
@@ -108,6 +117,9 @@ function Header({ config, status, onGistClick, onRunClick, onConfigChange }: Pro
                   </option>
                 ))}
               </Input>
+              <span className={`d-lg-none ${styles.mobileSep}`} aria-hidden="true">
+                |
+              </span>
               <Button
                 color="light"
                 className="me-2 mb-2 mb-lg-0"


### PR DESCRIPTION
### Description
Improve readability of header controls on mobile by adding clear separators between action controls.

- add lightweight mobile-only separators between Run/Gist/version/options controls
- add styles to keep separators aligned and visible in collapsed mobile layout

Closes #196

### Expected Behavior
On mobile, adjacent controls are visually separated so they no longer appear as a single unbroken string.
