### PR TITLE
Bump ast-serialize from 0.5.0 to 0.6.0 in master requirements

### DIFF
--- a/sandbox/cloud_functions/master/requirements.txt
+++ b/sandbox/cloud_functions/master/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
 librt==0.12.0
     # via mypy

--- a/sandbox/docker/master/requirements.txt
+++ b/sandbox/docker/master/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via mypy
 librt==0.12.0
     # via mypy


### PR DESCRIPTION
### Description
Bumps `ast-serialize` from 0.5.0 to 0.6.0 in the master sandbox requirements (`sandbox/cloud_functions/master/requirements.txt` and `sandbox/docker/master/requirements.txt`). `ast-serialize` is a transitive dependency pulled in via mypy; this keeps the pinned master builds in sync with the latest release. Follow-up to the recent `librt` bump (#1318).

### Expected Behavior
The master sandbox images (Docker and Cloud Functions) build against `ast-serialize==0.6.0`. mypy behavior is unchanged; only the pinned transitive dependency version is updated.