### PR TITLE
Update master sandbox requirements

### DIFF
--- a/sandbox/cloud_functions/master/requirements.txt
+++ b/sandbox/cloud_functions/master/requirements.txt
@@ -6,7 +6,7 @@
 #
 ast-serialize==0.6.0
     # via mypy
-librt==0.12.0
+librt==0.13.0
     # via mypy
 mypy @ git+https://github.com/python/mypy.git
     # via -r requirements.in
@@ -14,7 +14,7 @@ mypy-extensions==1.1.0
     # via mypy
 pathspec==1.1.1
     # via mypy
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r requirements.in
     #   mypy

--- a/sandbox/docker/master/requirements.txt
+++ b/sandbox/docker/master/requirements.txt
@@ -6,7 +6,7 @@
 #
 ast-serialize==0.6.0
     # via mypy
-librt==0.12.0
+librt==0.13.0
     # via mypy
 mypy @ git+https://github.com/python/mypy.git
     # via -r requirements.in
@@ -14,7 +14,7 @@ mypy-extensions==1.1.0
     # via mypy
 pathspec==1.1.1
     # via mypy
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via
     #   -r requirements.in
     #   mypy


### PR DESCRIPTION
### Description
Bump transitive dependencies in the master mypy sandbox requirements (both the Cloud Functions and Docker variants):

- `librt` 0.12.0 → 0.13.0
- `typing-extensions` 4.15.0 → 4.16.0

These are the pinned dependencies of the `master` mypy build, kept in sync between `sandbox/cloud_functions/master/requirements.txt` and `sandbox/docker/master/requirements.txt`.

### Expected Behavior
The master mypy sandbox images build and run against the updated dependency versions with no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)