### PR TITLE
Update master sandbox requirements

### DIFF
--- a/sandbox/cloud_functions/master/requirements.txt
+++ b/sandbox/cloud_functions/master/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile
 #
-ast-serialize==0.6.0
+ast-serialize==0.8.0
     # via mypy
-librt==0.13.0
+librt==0.15.0
     # via mypy
 mypy @ git+https://github.com/python/mypy.git
     # via -r requirements.in

--- a/sandbox/docker/master/requirements.txt
+++ b/sandbox/docker/master/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile
 #
-ast-serialize==0.6.0
+ast-serialize==0.8.0
     # via mypy
-librt==0.13.0
+librt==0.15.0
     # via mypy
 mypy @ git+https://github.com/python/mypy.git
     # via -r requirements.in


### PR DESCRIPTION
### Description
Bumps the pinned mypy dependencies for the master sandbox images:

- `ast-serialize` 0.6.0 -> 0.8.0
- `librt` 0.13.0 -> 0.15.0

Applied to both `sandbox/docker/master/requirements.txt` and `sandbox/cloud_functions/master/requirements.txt` so the two stay in sync. Keeps the master sandbox working with the current mypy master branch, which requires the newer versions.

### Expected Behavior
The master version of mypy in the playground continues to build and run type checks as before, with no user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)