### PR TITLE
Add Node.js 26 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [24.x, 25.x]
+        node-version: [24.x, 25.x, 26.x]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
### Description
Adds Node.js 26.x to the `test_frontend` matrix in `.github/workflows/ci.yml`, alongside the existing 24.x and 25.x entries. This is preparation for upgrading the project to Node.js 26: running the build, format check, lint, and tests on 26.x now surfaces any incompatibility before the actual upgrade.

Nothing else is switched over yet:

- The frontend artifact upload stays gated on `24.x`, since that build feeds `test_app` and matches the production image.
- `app/dockerfile/prod/Dockerfile` stays on `node:24` and `engines.node` in `app/frontend/package.json` stays `>=24`.

Once CI is green on 26.x, the upgrade itself is: bump the Dockerfile to `node:26`, bump `engines` to `>=26`, move the artifact upload condition, and drop 24.x from the matrix.

### Expected Behavior
CI runs the frontend job three times — on Node.js 24.x, 25.x, and 26.x — and all three pass. The frontend artifact is still produced exactly once, by the 24.x job, so `test_app` and the Docker image builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)