### PR TITLE
Upgrade Node.js to v26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [24.x, 25.x, 26.x]
+        node-version: [26.x]
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Use Node.js ${{ matrix.node-version }}
@@ -63,7 +63,7 @@ jobs:
         npm run test:ci
       working-directory: ./app/frontend
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: matrix.node-version == '24.x'
+      if: matrix.node-version == '26.x'
       with:
         name: frontend
         path: app/frontend/dist

--- a/app/dockerfile/prod/Dockerfile
+++ b/app/dockerfile/prod/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24
+FROM node:26
 
 COPY ./frontend/package.json ./frontend/package-lock.json /app/
 WORKDIR /app

--- a/app/frontend/Dockerfile
+++ b/app/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24
+FROM node:26
 
 COPY package.json package-lock.json /app/
 WORKDIR /app

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "^24.10.1",
+        "@types/node": "^26.2.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@typescript/native": "npm:typescript@^7.0.2",
@@ -40,7 +40,7 @@
         "vitest": "^4.1.6"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=26"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1323,13 +1323,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/react": {
@@ -4260,9 +4260,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -14,7 +14,7 @@
     "test:ci": "vitest run"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=26"
   },
   "dependencies": {
     "ace-builds": "^1.44.0",
@@ -29,7 +29,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^24.10.1",
+    "@types/node": "^26.2.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@typescript/native": "npm:typescript@^7.0.2",


### PR DESCRIPTION
### Description
Node.js 26 was added to the CI matrix in #1372 and passes, so this makes it the only supported version and drops 24 and 25.

- CI matrix collapses to `[26.x]`, and the frontend artifact upload guard moves to `26.x` so `test_app` still receives the `dist/` artifact.
- Both `node` base images — `app/frontend/Dockerfile` (local dev) and the build stage of `app/dockerfile/prod/Dockerfile` — move to `node:26`.
- `engines.node` becomes `>=26`, and `@types/node` moves from 24.10.1 to 26.2.0 to match the runtime we now require. That pulls `undici-types` 7.18.2 -> 8.3.0 as its transitive dependency; nothing else in the lockfile moved.

### Expected Behavior
CI runs a single `test_frontend` job on Node 26.x, which uploads the `frontend` artifact that `test_app` downloads. The dev and production Docker images build on `node:26`, and `npm ci` refuses to install on Node < 26.

Verified locally on Node 26.7.0 / npm 11.19.0: `npm ci`, `npm run build`, `npm run lint`, and `npm run test:ci` (9 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)